### PR TITLE
fix: small updates and polish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,4 +9,3 @@ tsconfig.json
 **/*.spec.*
 *.log
 **/*.tgz
-dist/**/*.map

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
 # Changelog
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
-
-### 1.0.2 (2019-09-27)

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "@google-cloud/storage": "^5.8.4",
-    "@types/vinyl": "^2.0.4",
     "ansi-colors": "^4.1.1",
     "fancy-log": "^1.3.3",
     "lodash.omit": "^4.5.0",
@@ -39,6 +38,7 @@
     "@types/lodash.omit": "^4.5.6",
     "@types/mime-types": "^2.1.0",
     "@types/node": "^14.14.41",
+    "@types/vinyl": "^2.0.4",
     "@types/through2-concurrent": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,9 +91,8 @@ export class Uploader {
   }
 
   /**
-   * Adds a file to the in-memory cache, to be persisted to disk later
+   * Removes a file cache from the cache file
    * @param path Path of file to cache
-   * @param hash Hash of file to cache
    */
   private removeFromCache(path: string): void {
     delete this.fileCache[path];
@@ -138,7 +137,7 @@ export class Uploader {
             if (err && [403, 404].indexOf(err.code) < 0) {
               return cb(err);
             } else {
-              // If the file isn't in the bucket, clear it from the cache, initialize empty metadata
+              // If the file isn't in the bucket, clear it from the cache
               if (!remoteMetadata) {
                 this.removeFromCache(file.gcs.path);
               }
@@ -206,7 +205,7 @@ export class Uploader {
       reportOptions = {};
     }
 
-    const stream = throughConcurrent.obj((file, enc, cb) => {
+    const stream = throughConcurrent.obj((file: Vinyl, enc, cb) => {
       let state: string;
 
       if (!file.gcs) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ export class Uploader {
   }
 
   /**
-   * Removes a file cache from the cache file
+   * Removes a file cache from the in-memory cache, to be persisted to disk later
    * @param path Path of file to cache
    */
   private removeFromCache(path: string): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export interface PluginOptions {
 }
 
 export interface ReportOptions {
-  states?: FileState;
+  states?: FileState[];
 }
 
 type FileState = 'cache' | 'skip' | 'update' | 'create';

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export interface PluginOptions {
 }
 
 export interface ReportOptions {
-  states?: FileState[];
+  states?: FileState;
 }
 
 type FileState = 'cache' | 'skip' | 'update' | 'create';


### PR DESCRIPTION
It is ok to keep `*.map` on release since we still have map comments inside of the core-js.

Also, found couple small comments we can update and move `@types/vinyl` to devDependencies!
