### PR TITLE
fix: add missing build command for npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
         run: |
           npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
           npm ci
+          npm run build
           npm run semantic-release
 
   merge-release:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
An attempted fix of npm-publish for semantic-release.


* **What is the current behavior?** (You can also link to an open issue here)
It is missing `dist` folder.


* **What is the new behavior (if this is a feature change)?**
It should build `dist` folder before publishing.


* **Other information**:
